### PR TITLE
Async OIDC SLC retrieval

### DIFF
--- a/cmd/aws-signing-proxy/main.go
+++ b/cmd/aws-signing-proxy/main.go
@@ -16,18 +16,39 @@ import (
 )
 
 type EnvConfig struct {
-	TargetUrl            string `split_words:"true"`
-	Port                 int    `default:"8080"`
-	HealthPort           int    `default:"8081"`
-	Service              string `default:"es"`
-	CredentialsProvider  string `split_words:"true"`
-	VaultUrl             string `split_words:"true"` // 'https://vaulthost'
-	VaultAuthToken       string `split_words:"true"` // auth-token for accessing Vault
-	VaultCredentialsPath string `split_words:"true"` // path were aws credentials can be generated/retrieved (e.g: 'aws/creds/my-role')
-	OpenIdAuthServerUrl  string `split_words:"true"`
-	OpenIdClientId       string `split_words:"true"`
-	OpenIdClientSecret   string `split_words:"true"`
-	RoleArn              string `split_words:"true"`
+	TargetUrl                   string `split_words:"true"`
+	Port                        int    `default:"8080"`
+	HealthPort                  int    `default:"8081"`
+	Service                     string `default:"es"`
+	CredentialsProvider         string `split_words:"true"`
+	VaultUrl                    string `split_words:"true"` // 'https://vaulthost'
+	VaultAuthToken              string `split_words:"true"` // auth-token for accessing Vault
+	VaultCredentialsPath        string `split_words:"true"` // path were aws credentials can be generated/retrieved (e.g: 'aws/creds/my-role')
+	OpenIdAuthServerUrl         string `split_words:"true"`
+	OpenIdClientId              string `split_words:"true"`
+	OpenIdClientSecret          string `split_words:"true"`
+	AsyncOpenIdCredentialsFetch bool   `split_words:"true"`
+	RoleArn                     string `split_words:"true"`
+}
+
+type Flags struct {
+	Target                      *string
+	Port                        *int
+	HealthPort                  *int
+	Service                     *string
+	CredentialProvider          *string
+	VaultUrl                    *string
+	VaultPath                   *string
+	VaultAuthToken              *string
+	OpenIdAuthServerUrl         *string
+	OpenIdClientId              *string
+	OpenIdClientSecret          *string
+	AsyncOpenIdCredentialsFetch *bool
+	RoleArn                     *string
+	Region                      *string
+	FlushInterval               *time.Duration
+	IdleConnTimeout             *time.Duration
+	DialTimeout                 *time.Duration
 }
 
 func main() {
@@ -37,78 +58,41 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
-	var targetFlag = flag.String("target", e.TargetUrl, "target url to proxy to (e.g. foo.eu-central-1.es.amazonaws.com)")
-	var portFlag = flag.Int("port", e.Port, "listening port for proxy (e.g. 3000)")
-	var healthPortFlag = flag.Int("healthPort", e.HealthPort, "Health port for proxy (e.g. 8081)")
-	var serviceFlag = flag.String("service", e.Service, "AWS Service (e.g. es)")
-
-	var credentialProviderFlag = flag.String("credentialsProvider", e.CredentialsProvider, "Either retrieve credentials via OpenID or Vault. Valid values are: oidc, vault")
-
-	// Vault
-	var vaultUrlFlag = flag.String("vaultUrl", e.VaultUrl, "base url of vault (e.g. 'https://foo.vault.invalid')")
-	var vaultPathFlag = flag.String("vaultPath", e.VaultCredentialsPath, "path for credentials (e.g. '/some-aws-engine/creds/some-aws-role')")
-	var vaultAuthTokenFlag = flag.String("vaultToken", e.VaultAuthToken, "token for authenticating with vault (NOTE: use the environment variable ASP_VAULT_AUTH_TOKEN instead)")
-
-	// openID Connect
-	var openIdAuthServerUrlFlag = flag.String("openIdAuthServerUrl", e.OpenIdAuthServerUrl, "The authorization server url")
-	var openIdClientIdFlag = flag.String("openIdClientId", e.OpenIdClientId, "OAuth client id")
-	var openIdClientSecretFlag = flag.String("openIdClientSecret", e.OpenIdClientSecret, "Oauth client secret")
-	var roleArnFlag = flag.String("roleArn", e.RoleArn, "AWS role ARN to assume to")
-
-	var regionFlag = flag.String("region", os.Getenv("AWS_REGION"), "AWS region for credentials (e.g. eu-central-1)")
-	var flushInterval = flag.Duration("flush-interval", 0, "non essential: flush interval to flush to the client while copying the response body.")
-	var idleConnTimeout = flag.Duration("idle-conn-timeout", 90*time.Second, "non essential: the maximum amount of time an idle (keep-alive) connection will remain idle before closing itself. zero means no limit.")
-	var dialTimeout = flag.Duration("dial-timeout", 30*time.Second, "non essential: the maximum amount of time a dial will wait for a connect to complete.")
-
-	flag.Parse()
+	var flags = Flags{}
+	parseFlags(&flags, e)
 
 	// Validate target URL
-	if anyFlagEmpty(*serviceFlag, *targetFlag) {
+	if anyFlagEmpty(*flags.Service, *flags.Target) {
 		log.Fatal("required parameter target (e.g. foo.eu-central-1.es.amazonaws.com) OR service (e.g. es) missing!")
 	}
-	targetURL, err := url.Parse(*targetFlag)
+	targetURL, err := url.Parse(*flags.Target)
 	if err != nil {
 		log.Fatal(err.Error())
 	}
 
 	// Region order of precedent:
 	// regionFlag > os.Getenv("AWS_REGION") > "eu-central-1"
-	region := *regionFlag
+	region := *flags.Region
 	if anyFlagEmpty(region) {
 		region = "eu-central-1"
 	}
 
 	var client proxy.ReadClient
 
-	if *credentialProviderFlag == "oidc" {
-		if anyFlagEmpty(*openIdClientIdFlag, *openIdClientSecretFlag, *openIdAuthServerUrlFlag, *roleArnFlag) {
+	if *flags.CredentialProvider == "oidc" {
+		if anyFlagEmpty(*flags.OpenIdClientId, *flags.OpenIdClientSecret, *flags.OpenIdAuthServerUrl, *flags.RoleArn) {
 			log.Fatal("Missing some needed flags for OIDC! Either: openIdClientId, openIdClientSecret, openIdAuthServerUrl or roleArn")
 		} else {
-			var oidcClient oidc.ReadClient
-			oidcClient = *oidc.NewOIDCClient(*regionFlag).
-				WithAuthServerUrl(*openIdAuthServerUrlFlag).
-				WithClientSecret(*openIdClientSecretFlag).
-				WithClientId(*openIdClientIdFlag).
-				WithRoleArn(*roleArnFlag).
-				Build()
-
-			scheduler := gocron.NewScheduler(time.UTC)
-			_, err := scheduler.Every(10).Seconds().StartImmediately().Do(func() { oidc.RetrieveCredentialsAheadOfTime(&oidcClient) })
-			if err != nil {
-				log.Fatalf("Scheduled Task for retrieving refreshed OIDC credentials failed! %s", err)
-			}
-
-			client = &oidcClient
-			log.Printf("- Using Credentials from from OIDC with Oauth2 Server '%s'\n", e.OpenIdAuthServerUrl)
+			client = newOidcClient(&flags, client, e)
 		}
-	} else if *credentialProviderFlag == "vault" {
-		if anyFlagEmpty(*vaultUrlFlag, *vaultPathFlag, *vaultAuthTokenFlag) {
+	} else if *flags.CredentialProvider == "vault" {
+		if anyFlagEmpty(*flags.VaultUrl, *flags.VaultPath, *flags.VaultAuthToken) {
 			log.Println("Warning: disabling vault credentials source due to missing flags/environment variables!")
 		} else {
 			client = vault.NewVaultClient().
-				WithBaseUrl(*vaultUrlFlag).
-				WithToken(*vaultAuthTokenFlag).
-				ReadFrom(*vaultPathFlag)
+				WithBaseUrl(*flags.VaultUrl).
+				WithToken(*flags.VaultAuthToken).
+				ReadFrom(*flags.VaultPath)
 			log.Printf("- Using Credentials from from Vault '%s' with credentialsPath '%s'\n", e.VaultUrl, e.VaultCredentialsPath)
 		}
 	}
@@ -116,14 +100,14 @@ func main() {
 	signingProxy := proxy.NewSigningProxy(proxy.Config{
 		Target:          targetURL,
 		Region:          region,
-		Service:         *serviceFlag,
-		FlushInterval:   *flushInterval,
-		IdleConnTimeout: *idleConnTimeout,
-		DialTimeout:     *dialTimeout,
+		Service:         *flags.Service,
+		FlushInterval:   *flags.FlushInterval,
+		IdleConnTimeout: *flags.IdleConnTimeout,
+		DialTimeout:     *flags.DialTimeout,
 		AuthClient:      client,
 	})
-	listenString := fmt.Sprintf(":%v", *portFlag)
-	healthPortString := fmt.Sprintf(":%v", *healthPortFlag)
+	listenString := fmt.Sprintf(":%v", *flags.Port)
+	healthPortString := fmt.Sprintf(":%v", *flags.HealthPort)
 	log.Printf("Listening on %v\n", listenString)
 	log.Printf("Forwarding Traffic to '%s'\n", targetURL)
 
@@ -131,6 +115,56 @@ func main() {
 
 	log.Fatal(http.ListenAndServe(listenString, signingProxy))
 
+}
+
+func parseFlags(flags *Flags, e EnvConfig) {
+	flags.Target = flag.String("target", e.TargetUrl, "target url to proxy to (e.g. foo.eu-central-1.es.amazonaws.com)")
+	flags.Port = flag.Int("port", e.Port, "listening port for proxy (e.g. 3000)")
+	flags.HealthPort = flag.Int("healthPort", e.HealthPort, "Health port for proxy (e.g. 8081)")
+	flags.Service = flag.String("service", e.Service, "AWS Service (e.g. es)")
+
+	flags.CredentialProvider = flag.String("credentialsProvider", e.CredentialsProvider, "Either retrieve credentials via OpenID or Vault. Valid values are: oidc, vault")
+
+	// Vault
+	flags.VaultUrl = flag.String("vaultUrl", e.VaultUrl, "base url of vault (e.g. 'https://foo.vault.invalid')")
+	flags.VaultPath = flag.String("vaultPath", e.VaultCredentialsPath, "path for credentials (e.g. '/some-aws-engine/creds/some-aws-role')")
+	flags.VaultAuthToken = flag.String("vaultToken", e.VaultAuthToken, "token for authenticating with vault (NOTE: use the environment variable ASP_VAULT_AUTH_TOKEN instead)")
+
+	// openID Connect
+	flags.OpenIdAuthServerUrl = flag.String("openIdAuthServerUrl", e.OpenIdAuthServerUrl, "The authorization server url")
+	flags.OpenIdClientId = flag.String("openIdClientId", e.OpenIdClientId, "OAuth client id")
+	flags.OpenIdClientSecret = flag.String("openIdClientSecret", e.OpenIdClientSecret, "Oauth client secret")
+	flags.AsyncOpenIdCredentialsFetch = flag.Bool("async-fetching", e.AsyncOpenIdCredentialsFetch, "Oauth client secret")
+	flags.RoleArn = flag.String("roleArn", e.RoleArn, "AWS role ARN to assume to")
+
+	flags.Region = flag.String("region", os.Getenv("AWS_REGION"), "AWS region for credentials (e.g. eu-central-1)")
+	flags.FlushInterval = flag.Duration("flush-interval", 0, "non essential: flush interval to flush to the client while copying the response body.")
+	flags.IdleConnTimeout = flag.Duration("idle-conn-timeout", 90*time.Second, "non essential: the maximum amount of time an idle (keep-alive) connection will remain idle before closing itself. zero means no limit.")
+	flags.DialTimeout = flag.Duration("dial-timeout", 30*time.Second, "non essential: the maximum amount of time a dial will wait for a connect to complete.")
+
+	flag.Parse()
+}
+
+func newOidcClient(flags *Flags, client proxy.ReadClient, e EnvConfig) proxy.ReadClient {
+	var oidcClient oidc.ReadClient
+	oidcClient = *oidc.NewOIDCClient(*flags.Region).
+		WithAuthServerUrl(*flags.OpenIdAuthServerUrl).
+		WithClientSecret(*flags.OpenIdClientSecret).
+		WithClientId(*flags.OpenIdClientId).
+		WithRoleArn(*flags.RoleArn).
+		Build()
+
+	if *flags.AsyncOpenIdCredentialsFetch == true {
+		scheduler := gocron.NewScheduler(time.UTC)
+		_, err := scheduler.Every(10).Seconds().StartImmediately().Do(func() { oidc.RetrieveCredentials(&oidcClient) })
+		if err != nil {
+			log.Fatalf("Scheduled Task for retrieving refreshed OIDC credentials failed! %s", err)
+		}
+	}
+
+	client = &oidcClient
+	log.Printf("- Using Credentials from from OIDC with Oauth2 Server '%s'\n", e.OpenIdAuthServerUrl)
+	return client
 }
 
 func provideHealthEndpoint(h string) {

--- a/cmd/aws-signing-proxy/main.go
+++ b/cmd/aws-signing-proxy/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/go-co-op/gocron"
 	"github.com/idealo/aws-signing-proxy/pkg/oidc"
 	"github.com/idealo/aws-signing-proxy/pkg/proxy"
 	"github.com/idealo/aws-signing-proxy/pkg/vault"
@@ -89,9 +90,13 @@ func main() {
 				WithClientSecret(*openIdClientSecretFlag).
 				WithClientId(*openIdClientIdFlag).
 				WithRoleArn(*roleArnFlag).
-				Read()
+				Build()
 
-			go oidc.RetrieveCredentialsAsync(&oidcClient)
+			scheduler := gocron.NewScheduler(time.UTC)
+			_, err := scheduler.Every(10).Seconds().StartImmediately().Do(func() { oidc.RetrieveCredentialsAheadOfTime(&oidcClient) })
+			if err != nil {
+				log.Fatalf("Scheduled Task for retrieving refreshed OIDC credentials failed! %s", err)
+			}
 
 			client = &oidcClient
 			log.Printf("- Using Credentials from from OIDC with Oauth2 Server '%s'\n", e.OpenIdAuthServerUrl)
@@ -103,7 +108,7 @@ func main() {
 			client = vault.NewVaultClient().
 				WithBaseUrl(*vaultUrlFlag).
 				WithToken(*vaultAuthTokenFlag).
-				Read(*vaultPathFlag)
+				ReadFrom(*vaultPathFlag)
 			log.Printf("- Using Credentials from from Vault '%s' with credentialsPath '%s'\n", e.VaultUrl, e.VaultCredentialsPath)
 		}
 	}

--- a/cmd/vault-env-cred-provider/main.go
+++ b/cmd/vault-env-cred-provider/main.go
@@ -72,7 +72,7 @@ func main() {
 	err = vault.NewVaultClient().
 		WithBaseUrl(*urlFlag).
 		WithToken(*authTokenFlag).
-		Read(*pathFlag).Into(fetchedCredentials)
+		ReadFrom(*pathFlag).RefreshCredentials(fetchedCredentials)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.36.11
-	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-co-op/gocron v1.9.0
 	github.com/kelseyhightower/envconfig v1.3.1-0.20170420212316-202b52d1dba0
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/aws/aws-sdk-go v1.36.11/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2z
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-co-op/gocron v1.9.0 h1:+V+DDenw3ryB7B+tK1bAIC5p0ruw4oX9IqAsdRnGIf0=
+github.com/go-co-op/gocron v1.9.0/go.mod h1:DbJm9kdgr1sEvWpHCA7dFFs/PGHPMil9/97EXCRPr4k=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
@@ -12,11 +14,17 @@ github.com/kelseyhightower/envconfig v1.3.1-0.20170420212316-202b52d1dba0/go.mod
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -27,3 +35,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/oidc/internal/http.go
+++ b/pkg/oidc/internal/http.go
@@ -59,10 +59,11 @@ func (p *PostRequest) WithClientCredentials(id string, secret string) *PostReque
 }
 
 type AuthServerResponse struct {
-	IdToken string `json:"idToken"`
+	IdToken   string `json:"idToken"`
+	ExpiresIn int    `json:"expires_in"`
 }
 
-func (p *PostRequest) Do(response interface{}) (*AuthServerResponse, error) {
+func (p *PostRequest) Do() (*AuthServerResponse, error) {
 	authServerUrl := p.httpClient.baseUrl
 	body, err := json.MarshalIndent(p.body, "", "")
 	if err != nil {

--- a/pkg/oidc/oidc.go
+++ b/pkg/oidc/oidc.go
@@ -99,6 +99,7 @@ func InitClient(region string) stsiface.STSAPI {
 func (c *ReadClient) RefreshCredentials(result interface{}) error {
 	refreshedCredentials := result.(*proxy.RefreshedCredentials)
 
+	RetrieveCredentials(c)
 	stsCredentials := cachedCredentials
 
 	refreshedCredentials.ExpiresAt = *stsCredentials.Expiration
@@ -109,7 +110,7 @@ func (c *ReadClient) RefreshCredentials(result interface{}) error {
 	return nil
 }
 
-func RetrieveCredentialsAheadOfTime(c *ReadClient) {
+func RetrieveCredentials(c *ReadClient) {
 	if cachedCredentials == nil || isExpired(cachedCredentials.Expiration) {
 		res, err := c.postRequest.Do()
 		if err != nil {
@@ -117,8 +118,6 @@ func RetrieveCredentialsAheadOfTime(c *ReadClient) {
 		}
 		cachedCredentials = c.retrieveShortLivingCredentialsFromAwsSts(c.roleArn, res.IdToken, c.clientId)
 		log.Println("Refreshed short living credentials.")
-	} else {
-		log.Println("Nothing to do.")
 	}
 }
 

--- a/pkg/oidc/oidc_test.go
+++ b/pkg/oidc/oidc_test.go
@@ -41,7 +41,7 @@ func TestRetrieveCredentialsAheadOfTime(t *testing.T) {
 	}
 	client := readClient.Build()
 
-	RetrieveCredentialsAheadOfTime(client)
+	RetrieveCredentials(client)
 
 	var accessKeyId, secretAccessKey, sessionToken string
 	accessKeyId = "accessKeyId"
@@ -59,7 +59,7 @@ func TestRetrieveCredentialsAheadOfTime(t *testing.T) {
 	got := cachedCredentials
 
 	if !reflect.DeepEqual(cachedCredentials, want) {
-		t.Errorf("RetrieveCredentialsAheadOfTime() = %v, want %v", got, want)
+		t.Errorf("RetrieveCredentials() = %v, want %v", got, want)
 	}
 
 	defer mockServer.Close()

--- a/pkg/oidc/oidc_test.go
+++ b/pkg/oidc/oidc_test.go
@@ -1,0 +1,111 @@
+package oidc
+
+import (
+	"encoding/json"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/aws/aws-sdk-go/service/sts/stsiface"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestRetrieveCredentialsAheadOfTime(t *testing.T) {
+
+	type MockOauthServerResponse struct {
+		IdToken   string `json:"id_token"`
+		ExpiresIn int    `json:"expires_in"`
+	}
+
+	mockServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := MockOauthServerResponse{
+			IdToken:   "shortLivedIdToken",
+			ExpiresIn: 3599,
+		}
+		bytes, _ := json.Marshal(response)
+		_, _ = w.Write(bytes)
+	}))
+
+	mockServer.Start()
+
+	readClient := ReadClient{
+		restClient:    nil,
+		httpClient:    nil,
+		postRequest:   nil,
+		stsClient:     &mockStsClient{},
+		authServerUrl: mockServer.URL,
+		clientId:      "client_id",
+		clientSecret:  "client_secret",
+		roleArn:       "role_arn",
+	}
+	client := readClient.Build()
+
+	RetrieveCredentialsAheadOfTime(client)
+
+	var accessKeyId, secretAccessKey, sessionToken string
+	accessKeyId = "accessKeyId"
+	secretAccessKey = "secretAccessKey"
+	sessionToken = "sessionToken"
+	var expiration = time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC).Add(time.Duration(60) * time.Minute)
+
+	want := &sts.Credentials{
+		AccessKeyId:     &accessKeyId,
+		Expiration:      &expiration,
+		SecretAccessKey: &secretAccessKey,
+		SessionToken:    &sessionToken,
+	}
+
+	got := cachedCredentials
+
+	if !reflect.DeepEqual(cachedCredentials, want) {
+		t.Errorf("RetrieveCredentialsAheadOfTime() = %v, want %v", got, want)
+	}
+
+	defer mockServer.Close()
+}
+
+func TestRetrieveShortLivingCredentials(t *testing.T) {
+	client := ReadClient{
+		stsClient: &mockStsClient{},
+	}
+
+	var accessKeyId, secretAccessKey, sessionToken string
+	accessKeyId = "accessKeyId"
+	secretAccessKey = "secretAccessKey"
+	sessionToken = "sessionToken"
+	var expiration = time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC).Add(time.Duration(60) * time.Minute)
+
+	want := &sts.Credentials{
+		AccessKeyId:     &accessKeyId,
+		Expiration:      &expiration,
+		SecretAccessKey: &secretAccessKey,
+		SessionToken:    &sessionToken,
+	}
+	got := client.retrieveShortLivingCredentialsFromAwsSts("foo", "bar", "session")
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("retrieveShortLivingCredentialsFromAwsSts() = %v, want %v", got, want)
+	}
+}
+
+type mockStsClient struct {
+	stsiface.STSAPI
+}
+
+func (*mockStsClient) AssumeRoleWithWebIdentity(*sts.AssumeRoleWithWebIdentityInput) (*sts.AssumeRoleWithWebIdentityOutput, error) {
+	var accessKeyId, secretAccessKey, sessionToken string
+	accessKeyId = "accessKeyId"
+	secretAccessKey = "secretAccessKey"
+	sessionToken = "sessionToken"
+	var expiration = time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC).Add(time.Duration(60) * time.Minute)
+
+	return &sts.AssumeRoleWithWebIdentityOutput{
+		Credentials: &sts.Credentials{
+			AccessKeyId:     &accessKeyId,
+			Expiration:      &expiration,
+			SecretAccessKey: &secretAccessKey,
+			SessionToken:    &sessionToken,
+		},
+	}, nil
+}

--- a/pkg/proxy/aws.go
+++ b/pkg/proxy/aws.go
@@ -8,7 +8,7 @@ import (
 )
 
 type ReadClient interface {
-	Into(result interface{}) error
+	RefreshCredentials(result interface{}) error
 }
 
 func NewCredChain(rc ReadClient) *credentials.Credentials {
@@ -53,7 +53,7 @@ type RefreshedCredentials struct {
 
 func (cp *CredentialProvider) Retrieve() (credentials.Value, error) {
 	c := &RefreshedCredentials{}
-	err := cp.client.Into(c)
+	err := cp.client.RefreshCredentials(c)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -40,7 +40,7 @@ type ReadClient struct {
 	getClient *internal.GetRequest
 }
 
-func (c *Client) Read(path string) *ReadClient {
+func (c *Client) ReadFrom(path string) *ReadClient {
 	if c.httpClient == nil {
 		c.httpClient = http.DefaultClient
 	}
@@ -59,7 +59,7 @@ func (c *Client) Read(path string) *ReadClient {
 	return r
 }
 
-func (r *ReadClient) Into(result interface{}) error {
+func (r *ReadClient) RefreshCredentials(result interface{}) error {
 	refreshedCreds := result.(*proxy.RefreshedCredentials)
 	err := r.getClient.Do(result)
 	refreshedCreds.ExpiresAt = time.Now().Add(time.Duration(refreshedCreds.LeaseDuration) * time.Second)

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -1,8 +1,10 @@
 package vault
 
 import (
+	"github.com/idealo/aws-signing-proxy/pkg/proxy"
 	"github.com/idealo/aws-signing-proxy/pkg/vault/internal"
 	"net/http"
+	"time"
 )
 
 type Client struct {
@@ -58,5 +60,8 @@ func (c *Client) Read(path string) *ReadClient {
 }
 
 func (r *ReadClient) Into(result interface{}) error {
-	return r.getClient.Do(result)
+	refreshedCreds := result.(*proxy.RefreshedCredentials)
+	err := r.getClient.Do(result)
+	refreshedCreds.ExpiresAt = time.Now().Add(time.Duration(refreshedCreds.LeaseDuration) * time.Second)
+	return err
 }


### PR DESCRIPTION
Retrieve SLC asynchronous via OIDC to avoid the longer taking requests due to the Oauth2 Server <-> STS Roundtrip.

I noticed that initial requests take up to 5 seconds to proceed as they wait for the first roundtrip to complete. That PR tackles that behaviour.