### PR TITLE
[Bug Fix] inverts check condition for presence of region flag

### DIFF
--- a/cmd/aws-signing-proxy/main.go
+++ b/cmd/aws-signing-proxy/main.go
@@ -73,7 +73,7 @@ func main() {
 	// Region order of precedent:
 	// regionFlag > os.Getenv("AWS_REGION") > "eu-central-1"
 	region := *regionFlag
-	if !anyFlagEmpty(region) {
+	if anyFlagEmpty(region) {
 		region = "eu-central-1"
 	}
 


### PR DESCRIPTION
I believe this is just a case of a flipped if-condition. Regardless of which region you set as a flag, the proxy always runs with `region=eu-central-1`. This fixes this behaviour.